### PR TITLE
Variable to choose which rake executable to use

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,6 +150,7 @@ Known config file settings (if you're familiar with capistrano and vlad these sh
     post_deploy_script:  path to a shell script to run after deployment
     post_setup_script:   path to a shell script to run after setup
     rake_env:            hash of environment variables to set when running post_setup and post_deploy rake tasks
+    rake_exec:           name of the rake executable to use (useful when using rvm) (default: rake)
 
 
 A simple config/deploy.yml might look like:

--- a/lib/whiskey_disk.rb
+++ b/lib/whiskey_disk.rb
@@ -72,6 +72,10 @@ class WhiskeyDisk
         buffer
       end
     end
+
+    def rake_exec
+      (self[:rake_exec] and self[:rake_exec] != '') ? self[:rake_exec] : 'rake'
+    end
     
     def parent_path(path)
       File.split(path).first
@@ -198,7 +202,7 @@ class WhiskeyDisk
     end
     
     def if_task_defined(task, cmd)
-      %Q(rakep=`#{env_vars} rake -P` && if [[ `echo "${rakep}" | grep #{task}` != "" ]]; then #{cmd}; fi )
+      %Q(rakep=`#{env_vars} #{rake_exec} -P` && if [[ `echo "${rakep}" | grep #{task}` != "" ]]; then #{cmd}; fi )
     end
     
     def safe_branch_checkout(path, my_branch)
@@ -222,7 +226,7 @@ class WhiskeyDisk
       enqueue "echo Running rake #{task_name}..."
       enqueue "cd #{path}"
       enqueue(if_file_present("#{self[:deploy_to]}/Rakefile", 
-        if_task_defined(task_name, "#{env_vars} rake #{'--trace' if Config.debug?} #{task_name} to=#{self[:environment]}")))
+        if_task_defined(task_name, "#{env_vars} #{rake_exec} #{'--trace' if Config.debug?} #{task_name} to=#{self[:environment]}")))
     end
     
     def build_path(path)

--- a/spec/whiskey_disk_spec.rb
+++ b/spec/whiskey_disk_spec.rb
@@ -718,6 +718,15 @@ describe 'WhiskeyDisk' do
         WhiskeyDisk.buffer.join(' ').should.match(%r{#{k}='#{v}' })
       end
     end
+
+    it "should use the configured rake executable if one is specified in the conf" do
+      @parameters = { 'deploy_to' => '/path/to/main/repo', 'rake_exec' => 'weird_exec' }
+      WhiskeyDisk.configuration = @parameters
+      WhiskeyDisk.run_post_deploy_hooks
+      WhiskeyDisk.buffer.join(' ').should =~ %r{weird_exec.*deploy:post_deploy}
+      WhiskeyDisk.buffer.join(' ').should =~ %r{rakep=\`.*weird_exec -P\` && if \[\[ \`echo "\$\{rakep\}" \| grep deploy:post_deploy\` != "" \]\];}
+      puts WhiskeyDisk.buffer.join(' ')
+    end
   end
   
   describe 'bundling up buffered commands for execution' do


### PR DESCRIPTION
In order to solve issue #16, I've added a config variable named rake_exec which will be use in order to invoke rake. 
The default value is obviously 'rake'

With RVM and a wrapper put in the setup script, I'm then able to have a fully functionnal rake.

Hope this helps
