### PR TITLE
Suppress git error messages when checking out master after cloning

### DIFF
--- a/lib/whiskey_disk.rb
+++ b/lib/whiskey_disk.rb
@@ -206,7 +206,9 @@ class WhiskeyDisk
   end
   
   def safe_branch_checkout(path, my_branch)
-    %Q(cd #{path} && git checkout -b #{my_branch} origin/#{my_branch} || git checkout #{my_branch} origin/#{my_branch} || git checkout #{my_branch})
+    %Q(cd #{path} && ) +
+      %Q((branch=`git symbolic-ref HEAD`; [ $branch == "refs/heads/#{my_branch}" ]) || ) +
+      %Q(git checkout -b #{my_branch} origin/#{my_branch} || git checkout #{my_branch} origin/#{my_branch} || git checkout #{my_branch})
   end
   
   def clone_repository(repo, path, my_branch)

--- a/spec/whiskey_disk_spec.rb
+++ b/spec/whiskey_disk_spec.rb
@@ -273,7 +273,12 @@ describe '@whiskey_disk' do
 
     it 'does branch checkouts from the repository path' do
       @whiskey_disk.checkout_main_repository
-      @whiskey_disk.buffer.join(' ').should.match(%r{cd /path/to/main/repo && git checkout})      
+      @whiskey_disk.buffer.join(' ').should.match(%r{git checkout})
+    end
+
+    it 'should verify if branch is already checked out' do
+      @whiskey_disk.checkout_main_repository
+      @whiskey_disk.buffer.join(' ').should.match(%r{cd /path/to/main/repo && \(branch=\`git symbolic-ref HEAD\`; \[ \$branch == "refs/heads/master" \]\) \|\| git checkout})
     end
   end
   


### PR DESCRIPTION
When the branch that is to be checked out on deployment is the master branch (which is very useful for development or QA environments), a number of git errors occur on `vd setup`.

Example:

```
Deploying test22...
Password: 
Cloning into example.com-preview...
fatal: git checkout: branch master already exists
error: pathspec 'origin/master' did not match any file(s) known to git.
Already on 'master'
Running post script...
Running rake deploy:post_setup...

Results:
test22 => succeeded.
Total: 1 deployment, 1 success, 0 failures.
```

Even though the deployment succeeded, the error messages are quite confusing. Especially since one error message reads "fatal", though it's not fatal at all (from the point of view of Whiskey Disk)!

This patch fixes this issue by avoiding any git checkout actions if the recently cloned git repository equals the branch that we want to have. It should avoid much confusion for people that attempt to deploy their master branch.

Thank you for creating Whiskey Disk -- it's been a pleasure to use!
